### PR TITLE
ST-12932 FIX [Rounding] Incorrect rounding due to binary floating point math

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@supplycart/ui",
-    "version": "2.0.1",
+    "version": "2.0.3",
     "repository": {
         "type": "git",
         "url": "https://github.com/supplycart/ui"

--- a/src/currency/components/MoneyV2.vue
+++ b/src/currency/components/MoneyV2.vue
@@ -36,7 +36,9 @@ export default {
                 .value();
 
             if (this.convertPrecision > -1) {
-                processedVal = processedVal.toFixed(this.convertPrecision);
+                // Use Decimal to avoid rounding issues caused by JS's floating-point math.
+                // Some numbers (like 1.005) can't be represented exactly and may round incorrectly.
+                processedVal = new Decimal(processedVal).toFixed(this.convertPrecision);
             }
             return (
                 (this.withSign && this.currencySignPos == "BEFORE"


### PR DESCRIPTION
Summary
- JavaScript’s floating-point math is approximate, not exact.

- Operations like num * 100 can introduce subtle errors before Math.round() even sees the value.

- This affects numbers like 1.005, 2.675, 0.615, etc.

- Best practice: use a decimal library for financial or precision-sensitive rounding.

Note: Use version `2.0.3` instead of `2.0.2` as `2.0.2` is already "locked" by a reverted changes previously.
